### PR TITLE
Fix possible data collision issue

### DIFF
--- a/Core/BPlusTree.cs
+++ b/Core/BPlusTree.cs
@@ -142,7 +142,7 @@ namespace BackupCore
                 // Is this node full?
                 if (node.Keys.Count > (NodeSize - 1)) // Nodesize-1 for keys
                 {
-                    SplitLeafNode(node);
+                    tail = SplitLeafNode(node);
                 }
 
                 return null;

--- a/Core/DiskFSInterop.cs
+++ b/Core/DiskFSInterop.cs
@@ -11,7 +11,7 @@ namespace BackupCore
 
         public bool FileExists(string absolutepath) => File.Exists(absolutepath);
 
-        public void CreateDirectory(string absolutepath) => Directory.CreateDirectory(absolutepath);
+        public void CreateDirectoryIfNotExists(string absolutepath) => Directory.CreateDirectory(absolutepath);
 
         public byte[] ReadAllFileBytes(string absolutepath) => File.ReadAllBytes(absolutepath);
 

--- a/Core/FSBlobStoreDependencies.cs
+++ b/Core/FSBlobStoreDependencies.cs
@@ -57,14 +57,8 @@ namespace BackupCore
             string path = Path.Combine(BlobSaveDirectory, relpath);
             try
             {
-                if (!FSInterop.DirectoryExists(dir1path))
-                {
-                    FSInterop.CreateDirectory(dir1path);
-                }
-                if (!FSInterop.DirectoryExists(dir2path))
-                {
-                    FSInterop.CreateDirectory(dir2path);
-                }
+                FSInterop.CreateDirectoryIfNotExists(dir1path);
+                FSInterop.CreateDirectoryIfNotExists(dir2path);
                 // NOTE: Right now every file is saved seperately
                 // (byteposition is always 0). In the future a packfile 
                 // may be added, so we continue specifying the byteposition

--- a/Core/FSCoreDependencies.cs
+++ b/Core/FSCoreDependencies.cs
@@ -180,16 +180,16 @@ namespace BackupCore
             // Make sure we have an index folder to write to later
             if (!FSInterop.DirectoryExists(id))
             {
-                FSInterop.CreateDirectory(id);
+                FSInterop.CreateDirectoryIfNotExists(id);
             }
             // Make sure we have a backup list folder to write to later
             if (!FSInterop.DirectoryExists(bsd))
             {
-                FSInterop.CreateDirectory(bsd);
+                FSInterop.CreateDirectoryIfNotExists(bsd);
             }
             if (!FSInterop.DirectoryExists(bdd))
             {
-                FSInterop.CreateDirectory(bdd);
+                FSInterop.CreateDirectoryIfNotExists(bdd);
             }
         }
 
@@ -331,7 +331,7 @@ namespace BackupCore
             }
             try
             {
-                FSInterop.CreateDirectory(path);
+                FSInterop.CreateDirectoryIfNotExists(path);
             }
             catch (Exception)
             {

--- a/Core/IFSInterop.cs
+++ b/Core/IFSInterop.cs
@@ -11,7 +11,7 @@ namespace BackupCore
 
         bool DirectoryExists(string absolutepath);
 
-        void CreateDirectory(string absolutepath);
+        void CreateDirectoryIfNotExists(string absolutepath);
 
         byte[] ReadAllFileBytes(string absolutepath);
 

--- a/Core/VirtualFSInterop.cs
+++ b/Core/VirtualFSInterop.cs
@@ -22,7 +22,16 @@ namespace BackupCore
 
         public bool DirectoryExists(string absolutepath) => VirtualFS.GetDirectory(absolutepath) != null;
 
-        public void CreateDirectory(string absolutepath) => VirtualFS.AddDirectory(Path.GetDirectoryName(absolutepath), MakeNewDirectoryMetadata(Path.GetFileName(absolutepath)));
+        public void CreateDirectoryIfNotExists(string absolutepath)
+        {
+            lock (this)
+            {
+                if (!DirectoryExists(absolutepath))
+                {
+                    VirtualFS.AddDirectory(Path.GetDirectoryName(absolutepath), MakeNewDirectoryMetadata(Path.GetFileName(absolutepath)));
+                }
+            }
+        }
 
         public byte[] ReadAllFileBytes(string absolutepath) => DataStore[VirtualFS.GetFile(absolutepath).FileHash];
 
@@ -118,10 +127,10 @@ namespace BackupCore
         // are not part of the IFSInterop interface. They are included as convenience methods for
         // use when creating a virtual filesystem
         public static FileMetadata MakeNewFileMetadata(string name, int size=0, byte[] hash = null) => new FileMetadata(name, new DateTime(),
-                                new DateTime(), new DateTime(), FileAttributes.Normal, size, hash);
+                                new DateTime(), new DateTime(), FileAttributes.Normal, size, hash, false);
 
 
         public static FileMetadata MakeNewDirectoryMetadata(string name) => new FileMetadata(name, new DateTime(),
-                                new DateTime(), new DateTime(), FileAttributes.Directory, 0, null);
+                                new DateTime(), new DateTime(), FileAttributes.Directory, 0, null, false);
     }
 }

--- a/CoreTest/BPlusTreeTest.cs
+++ b/CoreTest/BPlusTreeTest.cs
@@ -17,10 +17,10 @@ namespace CoreTest
         {
             BPTree = new BPlusTree<BlobLocation>(100);
 
-            testblob1 = new BlobLocation(BlobLocation.BlobTypes.FileBlob, false, "somewhere1", 0, 40);
-            BlobLocation bl2 = new BlobLocation(BlobLocation.BlobTypes.FileBlob, false, "somewhere2", 4, 401);
-            BlobLocation bl3 = new BlobLocation(BlobLocation.BlobTypes.FileBlob, false, "somewhere3", 0, 440);
-            BlobLocation bl4 = new BlobLocation(BlobLocation.BlobTypes.FileBlob, false, "somewhere4", 300, 74000);
+            testblob1 = new BlobLocation("somewhere1", 0, 40);
+            BlobLocation bl2 = new BlobLocation("somewhere2", 4, 401);
+            BlobLocation bl3 = new BlobLocation("somewhere3", 0, 440);
+            BlobLocation bl4 = new BlobLocation("somewhere4", 300, 74000);
 
             var rng = new Random();
 

--- a/CoreTest/BlobLocationTest.cs
+++ b/CoreTest/BlobLocationTest.cs
@@ -62,7 +62,7 @@ namespace CoreTest
         [TestMethod]
         public void TestSerializeDeserialize()
         {
-            BlobLocation old = new BlobLocation(BlobLocation.BlobTypes.FileBlob, false, "somewhere1", 0, 40);
+            BlobLocation old = new BlobLocation("somewhere1", 0, 40);
             BlobLocation deser = BlobLocation.deserialize(old.serialize());
             Assert.AreEqual(old, deser);
         }

--- a/CoreTest/CoreTest.cs
+++ b/CoreTest/CoreTest.cs
@@ -28,22 +28,22 @@ namespace CoreTest
             Dictionary<string, byte[]> verifyfilepaths = new Dictionary<string, byte[]>();
 
             (byte[] hash, byte[] file) = MakeRandomFile(10_000_000); // 10 MB file
-            AddFileToVFS(Path.Combine("src", "big"), hash, file);
+            //AddFileToVFS(Path.Combine("src", "big"), hash, file);
 
             (hash, file) = MakeRandomFile(0); // Empty file
-            AddFileToVFS(Path.Combine("src", "empty"), hash, file);
+            //AddFileToVFS(Path.Combine("src", "empty"), hash, file);
 
             (hash, file) = MakeRandomFile(1); // 1byte file
             AddFileToVFS(Path.Combine("src", "1b"), hash, file);
             
             (hash, file) = MakeRandomFile(2); // 2byte file
             AddFileToVFS(Path.Combine("src", "2b"), hash, file);
-
+            /*
             foreach (var num in Enumerable.Range(0, 200))
             {
                 (hash, file) = MakeRandomFile(55_000); // regular size file
                 AddFileToVFS(Path.Combine("src", String.Format("reg_{0}", num)), hash, file);
-            }
+            }*/
 
             return (verifydatastore, verifyfilepaths);
 
@@ -140,6 +140,7 @@ namespace CoreTest
         public void TestRemoveBackup()
         {
             var testdata = InitializeNewCoreWithStandardFiles();
+
             var bh1 = testdata.core.RunBackup("test", "run1");
             testdata.vfsroot.AddDirectory("src", VirtualFSInterop.MakeNewDirectoryMetadata("sub"));
             var bh2 = testdata.core.RunBackup("test", "run2");

--- a/LagernConsole/BackupBrowser.cs
+++ b/LagernConsole/BackupBrowser.cs
@@ -36,7 +36,7 @@ namespace BackupConsole
             BackupHash = targetbackuphashandrecord.hash;
             BackupStoreName = backupstorename;
             BackupCore.BackupRecord backuprecord = targetbackuphashandrecord.record;
-            BackupTree = BackupCore.MetadataNode.Load(BCore.Dependencies.DefaultBlobs, backuprecord.MetadataTreeHash);
+            BackupTree = BackupCore.MetadataNode.Load(BCore.Dependencies.DefaultBlobs, backuprecord.MetadataTreeHash, backuprecord.MetadataTreeMultiBlock);
             CurrentNode = BackupTree;
         }
 
@@ -158,7 +158,7 @@ namespace BackupConsole
             var targetbackuphashandrecord = BCore.Dependencies.DefaultBackups.GetBackupHashAndRecord(backuphash, opts.Offset);
             BackupHash = targetbackuphashandrecord.Item1;
             BackupCore.BackupRecord backuprecord = targetbackuphashandrecord.Item2;
-            BackupTree = BackupCore.MetadataNode.Load(BCore.Dependencies.DefaultBlobs, backuprecord.MetadataTreeHash);
+            BackupTree = BackupCore.MetadataNode.Load(BCore.Dependencies.DefaultBlobs, backuprecord.MetadataTreeHash, backuprecord.MetadataTreeMultiBlock);
             CurrentNode = BackupTree.GetDirectory(curpath);
             if (CurrentNode == null)
             {

--- a/LagernConsole/Program.cs
+++ b/LagernConsole/Program.cs
@@ -371,7 +371,7 @@ namespace BackupConsole
                 table.AddHeaderRow(new string[] { "Hash", "Saved", "RestoreSize", "BackupSize", "Message" });
                 for (int i = backups.Length - 1; i >= backups.Length - show; i--)
                 {
-                    var sizes = bcore.GetBackupSizes(backups[i].backuphash);
+                    var sizes = bcore.GetBackupSizes(bsname, backups[i].backuphash);
                     string message = backups[i].message;
                     int mlength = 40;
                     if (mlength > message.Length)

--- a/Testing/Program.cs
+++ b/Testing/Program.cs
@@ -22,15 +22,16 @@ namespace Testing
             //BlobStoreTest bstest = new BlobStoreTest();
             //bstest.TestSplitData();
 
-            //CoreTest.CoreTest ctest = new CoreTest.CoreTest();
+            CoreTest.CoreTest ctest = new CoreTest.CoreTest();
             //ctest.TestCheckTrackFile();
             //ctest.TestCheckTrackAnyDirectoryChild();
             //ctest.TestInitializeNew();
             //ctest.TestRunBackup();
             //ctest.TestRestore();
+            ctest.TestRemoveBackup();
 
-            BPlusTreeTest bptt = new BPlusTreeTest();
-            bptt.TestAddRemove();
+            //BPlusTreeTest bptt = new BPlusTreeTest();
+            //bptt.TestAddRemove();
 
             //MakeManyFiles(1000, 1000000, @"D:\src");
             //Console.WriteLine(TimeSimpleCopy(@"D:\src", @"D:\dst"));


### PR DESCRIPTION
Removed information about the type of data a blob represents from BlobLocation. This information must now be supplied when interpreting a blob.