### PR TITLE
Multiblock references are now only stored in the blob index.

### DIFF
--- a/Core/BinaryEncoding.cs
+++ b/Core/BinaryEncoding.cs
@@ -164,7 +164,7 @@ namespace BackupCore
                 }
                 else
                 {
-                    rawobjects.Add(key, null);
+                    rawobjects.Add(key, new byte[0]);
                     if (savedheaderbodynext.Count >= 3)
                     {
                         next = savedheaderbodynext[2];

--- a/CoreTest/BPlusTreeTest.cs
+++ b/CoreTest/BPlusTreeTest.cs
@@ -48,10 +48,10 @@ namespace CoreTest
         {
             var BPTree = new BPlusTree<BlobLocation>(100);
 
-            var testblob1 = new BlobLocation("somewhere1", 0, 40, true);
-            BlobLocation bl2 = new BlobLocation("somewhere2", 4, 401, false);
-            BlobLocation bl3 = new BlobLocation("somewhere3", 0, 440, true);
-            BlobLocation bl4 = new BlobLocation("somewhere4", 300, 74000, false);
+            var testblob1 = new BlobLocation("somewhere1", 0, 40);
+            BlobLocation bl2 = new BlobLocation("somewhere2", 4, 401);
+            BlobLocation bl3 = new BlobLocation(new byte[][] { new byte[] { 1, 2 }, new byte[] { 1, 0 } }.ToList());
+            BlobLocation bl4 = new BlobLocation();
 
             var rng = new Random();
 

--- a/CoreTest/BlobLocationTest.cs
+++ b/CoreTest/BlobLocationTest.cs
@@ -62,7 +62,7 @@ namespace CoreTest
         [TestMethod]
         public void TestSerializeDeserialize()
         {
-            BlobLocation old = new BlobLocation("somewhere1", 0, 40, true);
+            BlobLocation old = new BlobLocation("somewhere1", 0, 40);
             BlobLocation deser = BlobLocation.deserialize(old.serialize());
             Assert.AreEqual(old, deser);
         }

--- a/INPROGRESS.md
+++ b/INPROGRESS.md
@@ -3,18 +3,17 @@ For now this will remain the home of the project backlog.
 
 ====
 
-Fix for uploading hash lists
-	The hash used to store them is not the hash of their contents
-	Backblaze verifies uploads with a hash (a feature we currently use and want to continue to support)
-	Other services may do so as well, and may not be optional
-	Needed if we want to verify on write
+Hash lists in bloblocations not in blob data
 Data integrity and encryption support
+	Verify contents when retrieving from blobstore
+		Channel codes for hashlist blobs
 	Channel codes for backupset and blobstore files
-	Channel codes for hashlist blobs
 	Channel codes for blobs?
 		Make optional?
 		blob hash would have to be calculated from (blobdata + redundant bits) so entire file can easily be hash checked when using online services
 	Verify on write?
+		Backing up
+		Restoring
 Project structure change
 	Better API compliance
 		Public api only in Core

--- a/Testing/Program.cs
+++ b/Testing/Program.cs
@@ -20,17 +20,17 @@ namespace Testing
             //betest.TestDictEncodeDecode();
             //betest.TestEnumEncodeDecode();
 
-            //BlobStoreTest bstest = new BlobStoreTest();
+            BlobStoreTest bstest = new BlobStoreTest();
             //bstest.TestSplitData();
-            //bstest.TestBlobStoreDeserialize();
+            bstest.TestBlobStoreDeserialize();
 
-            CoreTest.CoreTest ctest = new CoreTest.CoreTest();
+            //CoreTest.CoreTest ctest = new CoreTest.CoreTest();
             //ctest.TestCheckTrackFile();
             //ctest.TestCheckTrackAnyDirectoryChild();
             //ctest.TestInitializeNew();
             //ctest.TestRunBackup();
             //ctest.TestRestore();
-            ctest.TestRemoveBackup();
+            //ctest.TestRemoveBackup();
             //ctest.TestInitializeNew();
             //ctest.TestLoadCore_NewlyInitialized();
 


### PR DESCRIPTION
They are no longer stored as their own blobs. This is more efficient,
and since the average blob size should be ~4MB, the size of the hash
list needed to store a large file is 1/4e6 * 20(hash len) = 1/200,000th
the size of the file in question.

Modified dict_decode so the objects with no length are returned as bytes
of length 0, not null. This produces the desired behavior for strings:
saving (mykey: "") -> string encode -> (mykey: byte[0]) -> dict_encode
-> dict_decode -> (mykey: byte[0]) -> string decode -> (mykey: "")