### PR TITLE
Closes #27 - Sequential or awaitable writes for tests

### DIFF
--- a/Core/BackupStore/BackupStoreDependencies.cs
+++ b/Core/BackupStore/BackupStoreDependencies.cs
@@ -23,7 +23,7 @@ namespace BackupCore
 
         public void StoreBackupSetData(string backupsetname, byte[] bsdata)
         {
-            DstFSInterop.StoreIndexFileAsync(backupsetname, IndexFileType.BackupSet, bsdata);
+            DstFSInterop.StoreIndexFileAsync(backupsetname, IndexFileType.BackupSet, bsdata).Wait();
         }
     }
 }

--- a/Core/BlobStore/BlobStoreDependencies.cs
+++ b/Core/BlobStore/BlobStoreDependencies.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace BackupCore
 {
@@ -15,7 +16,7 @@ namespace BackupCore
 
         public void DeleteBlob(byte[] encryptedHash, string fileId)
         {
-            DstFSInterop.DeleteBlobAsync(encryptedHash, fileId);
+            DstFSInterop.DeleteBlobAsync(encryptedHash, fileId).Wait();
         }
 
         public byte[] LoadBlob(byte[] hash)

--- a/Core/CoreDstDependencies.cs
+++ b/Core/CoreDstDependencies.cs
@@ -81,7 +81,7 @@ namespace BackupCore
 
         public void SaveBlobStoreIndex()
         {
-            DstFSInterop.StoreIndexFileAsync(null, IndexFileType.BlobIndex, Blobs.serialize());
+            DstFSInterop.StoreIndexFileAsync(null, IndexFileType.BlobIndex, Blobs.serialize()).Wait();
         }
 
         public void WriteSetting(BackupSetting key, string value)
@@ -102,6 +102,6 @@ namespace BackupCore
 
         private Stream GetSettingsFileStream() => new MemoryStream(DstFSInterop.LoadIndexFileAsync(null, IndexFileType.SettingsFile).Result);
 
-        private void WriteSettingsFileStreamAsync(byte[] data) => DstFSInterop.StoreIndexFileAsync(null, IndexFileType.SettingsFile, data);
+        private void WriteSettingsFileStreamAsync(byte[] data) => DstFSInterop.StoreIndexFileAsync(null, IndexFileType.SettingsFile, data).Wait();
     }
 }

--- a/Core/StorageInterop/DiskDstFSInterop.cs
+++ b/Core/StorageInterop/DiskDstFSInterop.cs
@@ -15,7 +15,7 @@ namespace BackupCore
             {
                 AesHelper encryptor = AesHelper.CreateFromPassword(password);
                 byte[] keyfile = encryptor.CreateKeyFile();
-                diskDstFSInterop.StoreIndexFileAsync(null, IndexFileType.EncryptorKeyFile, keyfile);
+                diskDstFSInterop.StoreIndexFileAsync(null, IndexFileType.EncryptorKeyFile, keyfile).Wait();
                 diskDstFSInterop.Encryptor = encryptor;
             }
             return diskDstFSInterop;
@@ -52,9 +52,9 @@ namespace BackupCore
             get => Path.Combine(DstPath, "index");
         }
 
-        public void DeleteBlobAsync(byte[] hash, string fileId)
+        public Task DeleteBlobAsync(byte[] hash, string fileId)
         {
-            Task.Run(() => File.Delete(Path.Combine(BlobSaveDirectory, GetBlobRelativePath(hash))));
+            return Task.Run(() => File.Delete(Path.Combine(BlobSaveDirectory, GetBlobRelativePath(hash))));
         }
 
         public Task<bool> IndexFileExistsAsync(string bsname, IndexFileType fileType)
@@ -94,14 +94,14 @@ namespace BackupCore
             return Task.Run(() => (hash, relpath));
         }
 
-        public void StoreIndexFileAsync(string bsname, IndexFileType fileType, byte[] data)
+        public Task StoreIndexFileAsync(string bsname, IndexFileType fileType, byte[] data)
         {
             // Never Encrypt Key File
             if (Encryptor != null && fileType != IndexFileType.EncryptorKeyFile)
             {
                 data = Encryptor.EncryptBytes(data);
             }
-            OverwriteOrCreateFileAsync(GetIndexFilePath(bsname, fileType), data);
+            return OverwriteOrCreateFileAsync(GetIndexFilePath(bsname, fileType), data);
         }
 
         private Task<byte[]> LoadFileAsync(string absolutepath)
@@ -109,9 +109,9 @@ namespace BackupCore
             return Task.Run(() => File.ReadAllBytes(absolutepath));
         }
 
-        public void OverwriteOrCreateFileAsync(string absolutepath, byte[] data)
+        public Task OverwriteOrCreateFileAsync(string absolutepath, byte[] data)
         {
-            Task.Run(() =>
+            return Task.Run(() =>
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(absolutepath));
 

--- a/Core/StorageInterop/IDstFSInterop.cs
+++ b/Core/StorageInterop/IDstFSInterop.cs
@@ -17,9 +17,9 @@ namespace BackupCore
 
         Task<bool> IndexFileExistsAsync(string bsname, IndexFileType fileType);
         Task<byte[]> LoadIndexFileAsync(string bsname, IndexFileType fileType);
-        void StoreIndexFileAsync(string bsname, IndexFileType fileType, byte[] data);
+        Task StoreIndexFileAsync(string bsname, IndexFileType fileType, byte[] data);
         Task<byte[]> LoadBlobAsync(byte[] encryptedHash);
         Task<(byte[] encryptedHash, string fileId)> StoreBlobAsync(byte[] rawHash, byte[] data);
-        void DeleteBlobAsync(byte[] encryptedHash, string fileId);
+        Task DeleteBlobAsync(byte[] encryptedHash, string fileId);
     }
 }


### PR DESCRIPTION
All asynchronous methods now return their spawned Task<>. Currently [with the exception of the main per file async backup in RunBackup()], all other async methods are blocked on (thus essentially running synchronously).

Opening successor issues #35 and #36